### PR TITLE
Add politics/ folder: public messaging for extramural outreach

### DIFF
--- a/politics/BRIEF.md
+++ b/politics/BRIEF.md
@@ -1,0 +1,87 @@
+# BayLeaf: Faculty-Controlled AI for Course Instruction
+
+A brief for faculty, governance committees, and anyone evaluating AI tools for
+higher education.
+
+---
+
+## The problem
+
+When a university deploys AI for instruction, the decision is typically made by IT
+procurement. The contract is signed with Google, Anthropic, Microsoft, or OpenAI.
+Faculty receive a preconfigured tool. Students use it. Neither can see the system
+prompt that shapes every interaction. Neither chose the model. Neither controls what
+the tool can access. The person who decides what AI tool you use in your classroom
+has never entered your classroom.
+
+This process takes 6–18 months and produces a tool optimized for institutional
+legibility, not pedagogical intent.
+
+Meanwhile, faculty are either using nothing or using unapproved tools with no
+guardrails.
+
+## The baseline
+
+Before evaluating any specific tool, institutions should establish minimum criteria.
+We propose five:
+
+1. **Transparency.** Students can see the system prompt and tool configuration.
+   They know what the model is told to do. They don't have to trust its self-report.
+
+2. **Faculty control.** The instructor writes the system prompt and selects the
+   tools for their course model. Configuration is a pedagogical act, not an IT
+   ticket.
+
+3. **Zero data retention on inference.** No student message content is stored by
+   any third-party model provider. Ever.
+
+4. **Vendor-switchable.** The model provider can be changed without rebuilding the
+   system. The intelligence is a commodity input, not a strategic dependency.
+
+5. **No new login.** Students authenticate with their existing institutional
+   identity. No new account. No new password. No new vendor relationship.
+
+These are not ambitious. They are minimal. Any tool that fails these criteria is
+asking faculty and students to accept less than they should.
+
+## What BayLeaf is
+
+BayLeaf is an open-source AI platform operated at UC Santa Cruz by a faculty member
+in Computational Media. It runs on [Open WebUI](https://openwebui.com/), routes
+inference through zero-data-retention providers, and gives each course a dedicated
+AI model whose system prompt is written by the instructor and visible to students.
+
+The core integration that connects AI models to Google Workspace (Drive, Docs,
+Sheets) is approximately 400 lines of code. It gives any user with an institutional
+Google account OAuth-consented access to their own files through any LLM. This is
+the empirical argument against the premise that AI-Workspace integration requires
+enterprise procurement.
+
+BayLeaf meets all five baseline criteria.
+
+### Current operation
+
+- Running at UCSC since Fall 2024
+- Multiple course models across departments
+- Students access via invite links shared through Canvas
+- Teachers configure models by editing a Canvas page — no new interface to learn
+- Model provider has been swapped multiple times with zero user disruption
+
+## The question
+
+Does your institution's current or planned AI tool meet the baseline?
+
+Ask your vendor:
+
+> *Can a faculty member see and edit the system prompt for their course's AI model?*
+
+> *Can a student read it?*
+
+> *Where does the conversation data go?*
+
+If the answer to any of these is unclear, the tool is not ready for the classroom.
+
+## Contact
+
+**Adam Smith** · Associate Professor, Computational Media, UC Santa Cruz
+[amsmith@ucsc.edu](mailto:amsmith@ucsc.edu) · [github.com/rndmcnlly/bayleaf](https://github.com/rndmcnlly/bayleaf)

--- a/politics/COMPARISON.md
+++ b/politics/COMPARISON.md
@@ -1,0 +1,39 @@
+# Comparison: BayLeaf vs. Enterprise AI Products
+
+This table evaluates AI-in-education products against the five baseline criteria
+defined in [POSITION.md](POSITION.md). Entries are based on publicly available
+documentation as of Spring 2026. Corrections welcome via issue or PR.
+
+## Baseline Criteria
+
+| Criterion | BayLeaf | Google Gemini for Education | Anthropic Claude for Enterprise | OpenAI ChatGPT Edu |
+|---|---|---|---|---|
+| **Student can read system prompt** | Yes. User story [student-4]. | No. System prompt set by Google. | No. Configurable by admin, not visible to end users. | No. Admin-configurable, not student-visible. |
+| **Faculty writes system prompt** | Yes. Teacher edits a Canvas page; BayLeaf syncs it to the model. | No. Gemini behavior controlled by Google product defaults. | Partial. Organization admin can set prompts; individual faculty cannot per-course. | Partial. Admin can create custom GPTs; per-course faculty authorship not standard. |
+| **Zero data retention on inference** | Yes. All inference via ZDR providers through OpenRouter. | No. Google's standard data processing terms apply. Workspace data feeds product improvement unless enterprise agreement specifies otherwise. | Depends on contract. Enterprise tier offers ZDR; education-specific terms vary. | Depends on contract. API usage can be ZDR; ChatGPT Edu terms vary by institution. |
+| **Vendor-switchable** | Yes. Model provider swapped overnight. Architecture is provider-agnostic. | No. Gemini is tightly integrated with Google Workspace. Switching means rebuilding the integration. | Partially. API-based usage is switchable; platform features create lock-in. | Partially. API is switchable; ChatGPT-specific features (custom GPTs, memory) are not. |
+| **Institutional identity (no new login)** | Yes. Google SSO via existing Workspace account. | Yes. Google identity native. | Depends on deployment. SAML/SSO available in enterprise tier. | Yes in Edu tier. SSO integration available. |
+
+## Beyond the baseline
+
+| Dimension | BayLeaf | Enterprise products |
+|---|---|---|
+| **One model per course** | Yes. Each course gets a dedicated model with its own prompt and tools. | No. Typically one instance per institution. |
+| **Teacher controls tool bindings** | Yes. Teacher selects from a vocabulary (Web, Code, Canvas, Drive). | No. Tool access determined by product defaults and admin settings. |
+| **Time from decision to deployment** | Hours. Faculty member edits a Canvas page. | 6–18 months through procurement. |
+| **Per-student marginal cost** | Near zero. Inference costs shared across usage. | Contract-dependent. Typically per-seat or per-institution licensing. |
+| **Open source** | Yes. Full stack visible at [github.com/rndmcnlly/bayleaf](https://github.com/rndmcnlly/bayleaf). | No. |
+| **Faculty can inspect all code** | Yes. | No. |
+| **Can be forked and modified** | Yes. | No. |
+
+## The question to ask vendors
+
+If you are evaluating an enterprise AI product for course instruction, ask:
+
+1. Can a faculty member write and edit the system prompt for their course's model?
+2. Can a student read it?
+3. Can the faculty member choose which tools the model has access to?
+4. What happens to student conversation data?
+5. If we want to switch providers next year, what breaks?
+
+Document the answers. Compare them to the baseline.

--- a/politics/DEPENDENCIES.md
+++ b/politics/DEPENDENCIES.md
@@ -1,0 +1,50 @@
+# Dependency Audit
+
+BayLeaf claims to be an alternative to vendor lock-in. This document audits every
+external dependency in the stack: who owns it, what the political profile is, what
+breaks if they change terms, and how fast we can switch. The framework is drawn from
+Audre Lorde's question — are these the master's tools? — applied as dependency
+analysis rather than rhetorical flourish.
+
+Honest answer up front: BayLeaf is a *legible* dependency with explicit exit paths.
+That is not liberation, but it is better than a procurement contract with a 5-year
+renewal and no exit clause.
+
+## Full stack
+
+| Layer | Provider | Owner | Political profile | Exit path | Switch cost |
+|---|---|---|---|---|---|
+| Code hosting | GitHub | Microsoft (CoreAI subdivision) | GitHub lost operational independence Aug 2025. ICE contract unresolved. Copilot trained on public repos without consent (lawsuit survived dismissal). | Codeberg mirror, flip canonical. | Low |
+| DNS / CDN / Workers | Cloudflare | Public (NYSE: NET) | Content moderation controversies. Traffic-level visibility into all requests. | Move Workers to any edge platform. | Moderate |
+| Chat hosting + DB | DigitalOcean | Public (NYSE: DOCN) | US cloud provider. Holds the OWUI PostgreSQL database: user accounts, conversation histories, access grants. | Migrate Docker + Postgres to any host. | Moderate |
+| Identity | Google Workspace (UCSC) | Google / UCSC admin | Sole authentication path. No fallback. Users do not exist to BayLeaf unless Google says they do. | Add secondary IdP (SAML). Requires institutional cooperation. | Hard |
+| LLM routing | OpenRouter | a16z, Menlo Ventures ($40M) | a16z founders donated $25M+ to Trump-aligned political committees in 2024. Every API call generates revenue flowing to a16z portfolio returns. | Direct API calls to providers or self-hosted inference. | Moderate |
+| Web search tool | Tavily | Nebius Group (ex-Yandex, $275M acquisition 2026) | Yandex successor entity. Microsoft $17B infrastructure deal. | Swap to SearXNG (self-hosted), Brave Search API, or similar. | Low |
+| Web reader tool | Jina AI | Berlin VC startup ($30M raised) | Low risk profile. | Swap reader API. | Trivial |
+| Code sandboxes | Daytona | VC-funded ($31M, FirstMark et al.) | Standard dev infra startup. | Any container orchestration platform. | Moderate |
+| LMS integration | Canvas (Instructure) | KKR ($4.8B acquisition 2024) | PE-owned edtech. PE optimizes for extraction on 5–7 year cycles. Deeply embedded in claim flow and course configuration. | Hard to replace. | High |
+| Application layer | Open WebUI | Open WebUI, Inc. (private company) | No formal governance, no foundation, no community steering committee. Active community debate about governance model. | Can fork. Maintaining fork solo is a different commitment than tracking upstream. | Moderate |
+
+## Structural observations
+
+**The ZDR boundary is narrower than it sounds.** "No message content is stored by
+any third-party provider" is true for the LLM inference path. The OWUI database on
+DigitalOcean stores user accounts, conversation histories, and access grants.
+Inference is ZDR. The application layer is not. The framing should not imply
+otherwise.
+
+**Google is ontological, not just operational.** Google is not one dependency among
+many. It is the identity layer. BayLeaf inherits the institution's Google dependency
+without alternative. There is no way to authenticate to BayLeaf without Google. This
+is the hardest dependency to exit and the one most subject to unilateral change by
+either Google or the institutional Workspace admin.
+
+**The "any faculty member could build this" claim has a credential problem.** The
+architecture is open and replicable. The operation depends on one person's Canvas
+token, Cloudflare account, and GCP project. Until a second person at a second
+institution independently deploys it, the claim is architectural, not empirical.
+
+**Environmental cost is unaccounted.** The multi-model architecture diffuses GPU
+usage across providers behind an abstraction layer. This makes environmental impact
+harder to measure, not easier. For a project whose user research identified
+environmental cost as a top student concern, this is a notable gap.

--- a/politics/POSITION.md
+++ b/politics/POSITION.md
@@ -1,0 +1,97 @@
+# Position: Infrastructure Is Pedagogy
+
+## The argument
+
+The system prompt is the pedagogical frame. The tool bindings are the capability
+boundary. The access model is the enrollment policy. These are not metaphors. When
+a vendor sets the system prompt, a vendor sets the pedagogical frame. When
+procurement selects the model, procurement selects the epistemology. When IT
+controls tool access, IT controls who learns with what.
+
+Every AI deployment in a course is a pedagogical decision. The question is whether
+that decision is made by the teacher or by someone else.
+
+## What procurement gets wrong
+
+Enterprise AI procurement optimizes for institutional legibility: one vendor, one
+contract, one dashboard, one compliance narrative. This is rational from the CIO's
+perspective. It is catastrophic from a pedagogical one.
+
+**Procurement removes the teacher from the design loop.** A Gemini for Education
+deployment gives every course the same model with the same defaults. The teacher
+cannot write a system prompt. The teacher cannot choose which tools the model has.
+The teacher cannot decide that *this* course's AI should be able to search the web
+but not access Drive, or that *that* course's AI should refuse to generate code.
+The design decisions that shape every student interaction are made by product
+managers at Google, not by the person who designed the syllabus.
+
+**Procurement creates vendor dependency disguised as infrastructure.** Once Canvas
+integrations, SSO, and workflows are built around a vendor's product, switching is
+not a technical decision — it's a political crisis. The vendor knows this. The
+contract is structured around it. The 5-year renewal is the goal, not the product.
+
+**Procurement is slow.** The typical timeline from "we should have an AI tool" to
+"students can use it in a course" is 6–18 months through formal channels. The
+technology changes faster than the process. By the time a tool is approved, its
+assumptions are stale.
+
+## What faculty control looks like
+
+A faculty-controlled AI tool has these properties:
+
+1. The teacher writes the system prompt for their course's model. This is the act
+   of articulating pedagogical intent in machine-readable form. It is intellectual
+   work, not configuration.
+
+2. The teacher selects which tools (web search, code execution, document access)
+   the model can use. Each tool binding is a decision about what the AI should be
+   able to do in the context of this course.
+
+3. The student can read the system prompt and see the tool selection. Transparency
+   is not optional. A student who cannot inspect the AI's instructions is in the
+   same position as a student who cannot read the syllabus.
+
+4. The model provider can be changed without disrupting the teacher's configuration
+   or the student's experience. The pedagogical layer (prompt, tools, access) is
+   decoupled from the inference layer (which company's GPU runs the model).
+
+5. No conversation data is retained by any third-party provider. Students are not
+   the training data.
+
+## The "any faculty member could build this" test
+
+The design principle is Illich's test for convivial tools: can the user understand,
+modify, and replace it? BayLeaf's architecture is designed so that any faculty
+member with basic technical literacy could, in principle, stand up an equivalent
+system for their institution using open-source components and commodity cloud
+services.
+
+This is not yet fully true operationally — the current deployment depends on one
+person's credentials and institutional access. Closing this gap is an active
+priority. But the architecture is honest: there is no proprietary component, no
+vendor SDK, no licensed dependency. The barrier to replication is documentation
+and operational knowledge, not intellectual property.
+
+## The dual power reading
+
+BayLeaf operates alongside institutional procurement, not against it. It uses
+existing institutional primitives — Canvas, SSO, Google Workspace — to build a
+governance model that procurement would never produce but that institutions can
+absorb. The architecture is designed so that if the institution decides to adopt
+BayLeaf formally, the admin can take over with no migration. And if the institution
+decides to shut it down, the admin can do that too. All authority flows through
+systems the institution already controls.
+
+This is not revolution. It is a demonstration that the alternative exists, is
+operational, and is cheaper than what procurement would buy.
+
+## The ask
+
+We are not asking institutions to adopt BayLeaf. We are asking them to adopt
+the *baseline*: transparency, faculty control, zero data retention,
+vendor-switchable architecture, institutional identity. Then evaluate every tool —
+including BayLeaf, including Gemini, including Claude — against that baseline.
+
+The tools that meet it will be the ones that treat faculty as professionals and
+students as people. The ones that don't will be the ones optimized for vendor
+lock-in.

--- a/politics/README.md
+++ b/politics/README.md
@@ -1,0 +1,24 @@
+# Politics
+
+BayLeaf is a political project. The choice of AI infrastructure is a pedagogical
+decision, and pedagogical decisions are political. This folder makes that explicit.
+
+These documents articulate why BayLeaf exists as an alternative to enterprise AI
+procurement, what principles any course AI tool should meet, and how the project's
+own dependencies constrain its claims.
+
+## Contents
+
+- [**BRIEF.md**](BRIEF.md) — Two-page summary for faculty governance committees
+  and cold outreach. Start here.
+- [**POSITION.md**](POSITION.md) — The full argument: infrastructure is pedagogy,
+  the baseline standard, and the vendor challenge.
+- [**COMPARISON.md**](COMPARISON.md) — BayLeaf vs. enterprise AI products on the
+  criteria that matter.
+- [**DEPENDENCIES.md**](DEPENDENCIES.md) — Honest accounting of every external
+  dependency, who owns it, and what the exit path looks like.
+
+## What's not here
+
+Tactical outreach plans, contact lists, and institution-specific strategy stay
+private. This folder is the platform, not the campaign.


### PR DESCRIPTION
## What

Adds `politics/` with four documents that capture BayLeaf's political argument in linkable, citable form:

- **BRIEF.md** — 2-page outreach document. The thing you attach to a cold email or drop in a Zoom chat. Defines the 5 baseline criteria and asks vendors the hard questions.
- **POSITION.md** — Full argument. Infrastructure is pedagogy. Procurement removes teachers from the design loop. The dual power reading.
- **COMPARISON.md** — Table: BayLeaf vs Gemini for Education vs Claude for Enterprise vs ChatGPT Edu on all 5 baseline criteria, plus dimensions beyond the baseline.
- **DEPENDENCIES.md** — Lorde audit of every dependency in the stack. Who owns it, political profile, exit path, switch cost. Moved and expanded from the issue #5 comment thread to a permanent home.

## Why

Per issue #5 discussion: the theory and self-criticism are done. The project needs outward-facing political messaging that faculty peers at other institutions can read in 5 minutes and governance committees can cite in recommendations. These documents serve that purpose.

## What's deliberately excluded

Tactical outreach plans, institution-specific profiles, named contacts, and sequencing. The folder is the public platform, not the campaign war room.

## Relationship to existing docs

- `IA-PLAN.md` frames the problem for UCSC stakeholders. `politics/` frames it for anyone.
- Issue #5 `THEORY.md` comment provides theoretical grounding. `POSITION.md` distills it into argument.
- Issue #5 Lorde audit comment is the raw analysis. `DEPENDENCIES.md` is the cleaned-up permanent version.

The ghpages docs site (`docs/`) is not touched here. A follow-up will add a "Beyond UCSC" section after real outreach conversations reveal what the actual barriers to independent deployment are.